### PR TITLE
Fix: Move Warning to Top

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@
 
 </div>
 
+## Safety and Security Disclaimer
+
+> [!WARNING]
+> **Use these services at your own risk.**
+>
+>   Assume that anything you type (prompts, files, personal details) is logged, stored, or shared.  
+>   Do **not** send sensitive or confidential information unless you fully trust the operator.
+>
+> **Reliability** – Free services disappear, rate-limit, or change their models without notice.  
+>   Never depend on them for production workloads, academic citations, or long-term storage.
+>
+> The maintainer of this repository has **no affiliation** with the listed sites and cannot guarantee their safety, legality, quality, or continued availability.
+
 ---
 
 ## Leaderboards
@@ -208,14 +221,3 @@
 
 Contributions are welcome. Please open an issue or pull request to add a service or update existing information. Ensure all additions follow the established format.
 
-
-> [!WARNING]
-> **Use these services at your own risk.**
->
->   Assume that anything you type (prompts, files, personal details) is logged, stored, or shared.  
->   Do **not** send sensitive or confidential information unless you fully trust the operator.
->
-> **Reliability** – Free services disappear, rate-limit, or change their models without notice.  
->   Never depend on them for production workloads, academic citations, or long-term storage.
->
-> The maintainer of this repository has **no affiliation** with the listed sites and cannot guarantee their safety, legality, quality, or continued availability.


### PR DESCRIPTION
## In this PR

### What?

- Moved the warning to the top of the README as "Disclaimer" section

### Why?

- The warning can easily be missed since it was at the bottom