### PR TITLE
Add Seedream AI Studio — free-tier multi-model image gen + Kling 2.1 video

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@
 | [krea.ai](https://www.krea.ai) | `krea-1`, `flux.1-krea`, and other SD/Flux based models | 50 generations per day, with Watermark |
 | [app.pixverse.ai](https://app.pixverse.ai) | PixVerse video | 50-60 per day, 540p or 750p output, with Watermark |
 | [ideogram.ai](https://ideogram.ai) | `ideogram-3.0`, `ideogram-3.0-turbo` | 10 credits per week (40 images per week), with Watermark |
+| [seedream4.video](https://seedream4.video/) | `seedream-5.0`, `seedream-4.5`, `seedream-4.0`, `kling-2.1` (image-to-video) | Free tier available; multi-model AI image generation by ByteDance |
 | [genmo.ai](https://www.genmo.ai) | `mochi-1` | 50 credits per month, with Watermark |
 
 ### Voice & Music


### PR DESCRIPTION
## What

Adds [Seedream AI Studio](https://seedream4.video/) to the **Image/Video/Multimodal** section of the free-tier table.

| Field | Value |
|---|---|
| Link | https://seedream4.video/ |
| Free Models | seedream-5.0, seedream-4.5, seedream-4.0, kling-2.1 (image-to-video) |
| Limits | Free tier available (multi-model AI image generation by ByteDance) |

## Why

Seedream AI Studio offers ByteDance's Seedream 5.0/4.5/4.0 text-to-image models plus one-click image-to-video animation via Kling 2.1 — all with a free tier. It fills a gap between fully free tools and paid-only platforms in this list.